### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -11,20 +11,20 @@
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin   KEYWORD2
-poll    KEYWORD2
-touchDetected   KEYWORD2
-triangleTouched KEYWORD2
-squareTouched   KEYWORD2
-circleTouched   KEYWORD2
-crossTouched    KEYWORD2
-getTouch    KEYWORD2
+begin	KEYWORD2
+poll	KEYWORD2
+touchDetected	KEYWORD2
+triangleTouched	KEYWORD2
+squareTouched	KEYWORD2
+circleTouched	KEYWORD2
+crossTouched	KEYWORD2
+getTouch	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-TRIANGLE    LITERAL1
-CIRCLE  LITERAL1
-SQUARE  LITERAL1
-CROSS   LITERAL1
+TRIANGLE	LITERAL1
+CIRCLE	LITERAL1
+SQUARE	LITERAL1
+CROSS	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords